### PR TITLE
Fix misleading declaration of material properties "tau" and "g"

### DIFF
--- a/generic-behaviours/hyperviscoelasticity/SignoriniHyperviscoelasticity.mfront
+++ b/generic-behaviours/hyperviscoelasticity/SignoriniHyperviscoelasticity.mfront
@@ -16,8 +16,8 @@ K.setGlossaryName("BulkModulus");
 @MaterialProperty stress C20;
 @MaterialProperty stress C01;
 
-@MaterialProperty stress tau[Nv];
-@MaterialProperty stress g[Nv];
+@MaterialProperty time tau[Nv];
+@MaterialProperty real g[Nv];
 
 @StateVariable StressStensor Si;
 Si.setEntryName("IsochoricElasticStress");


### PR DESCRIPTION
Based on the definition of the viscoelastic stress, `tau ` should be declared as `time` whereas `g` should be non-dimensional.
```
  StressStensor S = Sv+Si;
  if(dt>0){
    for(unsigned short i=0;i!=Nv;++i){
      const auto dtr = dt/tau[i];
      e[i] = exp(-dtr);
      H[i] = e[i]*H[i]+g[i]*(1-e[i])/(dtr)*(Si-Si_1);
      S += H[i];
    }
  }
```