### PR TITLE
Enable "make package_source"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,3 +33,8 @@ add_subdirectory(unit-tests/tfel-check)
 if(enable-website)
   add_subdirectory(docs/web)
 endif(enable-website)
+
+set(CPACK_VERBATIM_VARIABLES YES)
+set(CPACK_SOURCE_GENERATOR "TGZ")
+set(CPACK_SOURCE_IGNORE_FILES "build;/\\.git/;.*~")
+include(CPack)


### PR DESCRIPTION
Dear Mr. Thomas Helfer,

With this pull request, it is possible to run "make package_source" (e.g. MFrontGallery-0.1.1-Source.tar.gz to be included in a public docker container).
```
Run CPack packaging tool for source...
CPack: Create package using TGZ
CPack: Install projects
CPack: - Install directory: ~/install/MFrontGallery
CPack: Create package
CPack: - package: ~/install/MFrontGallery-build/MFrontGallery-0.1.1-Source.tar.gz generated.
```
Reinhard